### PR TITLE
feat: add kusto scalar functions: now(), toupper(), tolower()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# binaries in cmd/
+pql

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ list will be passed through to the underlying SQL engine. This allows the usage
 of the full APIs implemented by the underlying
 
 - [`not`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/not-function)
+- [`now`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/now-function)
 - [`isnull`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/isnull-function)
   and [`isnotnull`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/isnotnull-function)
 - [`strcat`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/strcat-function)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ of the full APIs implemented by the underlying
 - [`iff`/`iif`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/iff-function)
 - [`count`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/count-aggregation-function)
 - [`countif`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/countif-aggregation-function)
+- [`tolower`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/tolower-function)
 
 Column names with special characters can be escaped with backticks.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ of the full APIs implemented by the underlying
 - [`count`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/count-aggregation-function)
 - [`countif`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/countif-aggregation-function)
 - [`tolower`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/tolower-function)
+- [`toupper`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/toupper-function)
+
 
 Column names with special characters can be escaped with backticks.
 

--- a/pql.go
+++ b/pql.go
@@ -721,6 +721,7 @@ func initKnownFunctions() map[string]*functionRewrite {
 			"now":       {write: writeNowFunction},
 			"strcat":    {write: writeStrcatFunction, needsParens: true},
 			"tolower":   {write: writeToLowerFunction, needsParens: true},
+			"toupper":   {write: writeToUpperFunction, needsParens: true},
 		}
 	})
 	return knownFunctions.m
@@ -891,6 +892,25 @@ func writeToLowerFunction(ctx *exprContext, sb *strings.Builder, x *parser.CallE
 		}
 	}
 	sb.WriteString("LOWER(")
+	if err := writeExpression(ctx, sb, x.Args[0]); err != nil {
+		return err
+	}
+	sb.WriteString(")")
+	return nil
+}
+
+func writeToUpperFunction(ctx *exprContext, sb *strings.Builder, x *parser.CallExpr) error {
+	if len(x.Args) != 1 {
+		return &compileError{
+			source: ctx.source,
+			span: parser.Span{
+				Start: x.Lparen.End,
+				End:   x.Rparen.Start,
+			},
+			err: fmt.Errorf("toupper(x) takes a single argument (got %d)", len(x.Args)),
+		}
+	}
+	sb.WriteString("UPPER(")
 	if err := writeExpression(ctx, sb, x.Args[0]); err != nil {
 		return err
 	}

--- a/pql.go
+++ b/pql.go
@@ -720,6 +720,7 @@ func initKnownFunctions() map[string]*functionRewrite {
 			"not":       {write: writeNotFunction},
 			"now":       {write: writeNowFunction},
 			"strcat":    {write: writeStrcatFunction, needsParens: true},
+			"tolower":   {write: writeToLowerFunction, needsParens: true},
 		}
 	})
 	return knownFunctions.m
@@ -875,6 +876,25 @@ func writeIfFunction(ctx *exprContext, sb *strings.Builder, x *parser.CallExpr) 
 		return err
 	}
 	sb.WriteString(" END")
+	return nil
+}
+
+func writeToLowerFunction(ctx *exprContext, sb *strings.Builder, x *parser.CallExpr) error {
+	if len(x.Args) != 1 {
+		return &compileError{
+			source: ctx.source,
+			span: parser.Span{
+				Start: x.Lparen.End,
+				End:   x.Rparen.Start,
+			},
+			err: fmt.Errorf("tolower(x) takes a single argument (got %d)", len(x.Args)),
+		}
+	}
+	sb.WriteString("LOWER(")
+	if err := writeExpression(ctx, sb, x.Args[0]); err != nil {
+		return err
+	}
+	sb.WriteString(")")
 	return nil
 }
 

--- a/pql.go
+++ b/pql.go
@@ -711,14 +711,15 @@ var knownFunctions struct {
 func initKnownFunctions() map[string]*functionRewrite {
 	knownFunctions.init.Do(func() {
 		knownFunctions.m = map[string]*functionRewrite{
-			"not":       {write: writeNotFunction},
-			"isnull":    {write: writeIsNullFunction, needsParens: true},
-			"isnotnull": {write: writeIsNotNullFunction, needsParens: true},
-			"strcat":    {write: writeStrcatFunction, needsParens: true},
 			"count":     {write: writeCountFunction},
 			"countif":   {write: writeCountIfFunction},
-			"iff":       {write: writeIfFunction, needsParens: true},
 			"iif":       {write: writeIfFunction, needsParens: true},
+			"iff":       {write: writeIfFunction, needsParens: true},
+			"isnotnull": {write: writeIsNotNullFunction, needsParens: true},
+			"isnull":    {write: writeIsNullFunction, needsParens: true},
+			"not":       {write: writeNotFunction},
+			"now":       {write: writeNowFunction},
+			"strcat":    {write: writeStrcatFunction, needsParens: true},
 		}
 	})
 	return knownFunctions.m
@@ -739,6 +740,21 @@ func writeNotFunction(ctx *exprContext, sb *strings.Builder, x *parser.CallExpr)
 	if err := writeExpressionMaybeParen(ctx, sb, x.Args[0]); err != nil {
 		return err
 	}
+	return nil
+}
+
+func writeNowFunction(ctx *exprContext, sb *strings.Builder, x *parser.CallExpr) error {
+	if len(x.Args) != 0 {
+		return &compileError{
+			source: ctx.source,
+			span: parser.Span{
+				Start: x.Lparen.End,
+				End:   x.Rparen.Start,
+			},
+			err: fmt.Errorf("now()) takes a no arguments (got %d)", len(x.Args)),
+		}
+	}
+	sb.WriteString("CURRENT_TIMESTAMP")
 	return nil
 }
 

--- a/testdata/Goldens/ProjectNow/input.pql
+++ b/testdata/Goldens/ProjectNow/input.pql
@@ -1,0 +1,2 @@
+StormEvents
+| project now = now(), State

--- a/testdata/Goldens/ProjectNow/output.sql
+++ b/testdata/Goldens/ProjectNow/output.sql
@@ -1,0 +1,1 @@
+SELECT CURRENT_TIMESTAMP AS "now", "State" AS "State" FROM "StormEvents";

--- a/testdata/Goldens/WhereToLower/input.pql
+++ b/testdata/Goldens/WhereToLower/input.pql
@@ -1,0 +1,2 @@
+StormEvents
+| where tolower(EventType) == "tornado"

--- a/testdata/Goldens/WhereToLower/output.csv
+++ b/testdata/Goldens/WhereToLower/output.csv
@@ -1,0 +1,2 @@
+EventId,State,EventType,DamageProperty
+60913,FLORIDA,Tornado,6200000

--- a/testdata/Goldens/WhereToLower/output.sql
+++ b/testdata/Goldens/WhereToLower/output.sql
@@ -1,0 +1,1 @@
+SELECT * FROM "StormEvents" WHERE coalesce((LOWER("EventType")) = 'tornado', FALSE);

--- a/testdata/Goldens/WhereToUpper/input.pql
+++ b/testdata/Goldens/WhereToUpper/input.pql
@@ -1,0 +1,2 @@
+StormEvents
+| where toupper(EventType) == "TORNADO"

--- a/testdata/Goldens/WhereToUpper/output.csv
+++ b/testdata/Goldens/WhereToUpper/output.csv
@@ -1,0 +1,2 @@
+EventId,State,EventType,DamageProperty
+60913,FLORIDA,Tornado,6200000

--- a/testdata/Goldens/WhereToUpper/output.sql
+++ b/testdata/Goldens/WhereToUpper/output.sql
@@ -1,0 +1,1 @@
+SELECT * FROM "StormEvents" WHERE coalesce((UPPER("EventType")) = 'TORNADO', FALSE);


### PR DESCRIPTION
Adds a few simple Kusto functions backed by ANSI SQL standard functions. Tested compatibility with ClickHouse, SQLite, Snowflake and Postgres engines. 