### PR TITLE
Slight bug with extend, might also exist with project

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -427,20 +427,26 @@ func (p *parser) extendOperator(pipe, keyword Token) (*ExtendOperator, error) {
 		if !ok {
 			return op, fmt.Errorf("expected '=' followed by expression for assignment, got EOF")
 		}
-		switch sep.Kind {
-		case TokenAssign:
-			col.Assign = sep.Span
-			col.X, err = p.expr()
-			if err != nil {
-				return op, makeErrorOpaque(err)
-			}
-			sep, ok = p.next()
-			if !ok || sep.Kind != TokenComma {
-				return op, nil
-			}
-		default:
-			p.prev()
+
+		// Unlike in project, extend must be an assignment after
+		// the column name token. And afterwards the token must be
+		// a comma as a separator
+		if sep.Kind != TokenAssign {
+			return op, makeErrorOpaque(err)
+		}
+
+		col.Assign = sep.Span
+		col.X, err = p.expr()
+		if err != nil {
+			return op, makeErrorOpaque(err)
+		}
+		sep, ok = p.next()
+		if !ok {
 			return op, nil
+		}
+		if sep.Kind != TokenComma {
+			return op, fmt.Errorf("expected '=' followed by expression for assignment, got EOF")
+
 		}
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1183,6 +1183,42 @@ var parserTests = []struct {
 		},
 	},
 	{
+		name:  "ExtendError",
+		query: "StormEvents | extend FooFooF=1 State",
+		err:   true,
+		want: &TabularExpr{
+			Source: &TableRef{
+				Table: &Ident{
+					Name:     "StormEvents",
+					NameSpan: newSpan(0, 11),
+				},
+			},
+			Operators: []TabularOperator{
+				&ExtendOperator{
+					Pipe:    newSpan(12, 13),
+					Keyword: newSpan(14, 20),
+					Cols: []*ExtendColumn{
+						{
+							Name: &Ident{
+								Name:     "FooFooF",
+								NameSpan: newSpan(21, 28),
+							},
+							Assign: Span{
+								Start: 28,
+								End:   29,
+							},
+							X: &BasicLit{
+								Kind:      TokenNumber,
+								Value:     "1",
+								ValueSpan: newSpan(29, 30),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
 		name:  "UniqueCombination",
 		query: "StormEvents | summarize by State, EventType",
 		want: &TabularExpr{


### PR DESCRIPTION
There's a slight parsing issue with `extend` that also might exist for project. Currently `extend a=1 bb` doesn't throw an error, instead it just ignores bb (which is minor but not correct).

This change simplifies the parsing logic for the extendOperator.