### PR TITLE
Fix project, minor parsing bug.

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -396,8 +396,11 @@ func (p *parser) projectOperator(pipe, keyword Token) (*ProjectOperator, error) 
 				return op, makeErrorOpaque(err)
 			}
 			sep, ok = p.next()
-			if !ok || sep.Kind != TokenComma {
+			if !ok {
 				return op, nil
+			}
+			if sep.Kind != TokenComma {
+				return op, fmt.Errorf("expected ',' or EOF, got %s", formatToken(p.source, sep))
 			}
 		default:
 			p.prev()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1105,6 +1105,34 @@ var parserTests = []struct {
 		},
 	},
 	{
+		name:  "ProjectError",
+		query: "StormEvents | project EventId State EventType",
+		err:   true,
+		want: &TabularExpr{
+			Source: &TableRef{
+				Table: &Ident{
+					Name:     "StormEvents",
+					NameSpan: newSpan(0, 11),
+				},
+			},
+			Operators: []TabularOperator{
+				&ProjectOperator{
+					Pipe:    newSpan(12, 13),
+					Keyword: newSpan(14, 21),
+					Cols: []*ProjectColumn{
+						{
+							Name: &Ident{
+								Name:     "EventId",
+								NameSpan: newSpan(22, 29),
+							},
+							Assign: nullSpan(),
+						},
+					},
+				},
+			},
+		},
+	},
+	{
 		name:  "ProjectExpr",
 		query: "StormEvents | project TotalInjuries = InjuriesDirect + InjuriesIndirect",
 		want: &TabularExpr{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1106,7 +1106,7 @@ var parserTests = []struct {
 	},
 	{
 		name:  "ProjectError",
-		query: "StormEvents | project EventId State EventType",
+		query: "StormEvents | project EventId=1 State",
 		err:   true,
 		want: &TabularExpr{
 			Source: &TableRef{
@@ -1125,7 +1125,15 @@ var parserTests = []struct {
 								Name:     "EventId",
 								NameSpan: newSpan(22, 29),
 							},
-							Assign: nullSpan(),
+							Assign: Span{
+								Start: 29,
+								End:   30,
+							},
+							X: &BasicLit{
+								Kind:      TokenNumber,
+								Value:     "1",
+								ValueSpan: newSpan(30, 31),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
It appears project is slightly too permissive in the same way that extend was. `project id b` is invalid, same as `project id=1 b`.

Ensure we are requiring a comma or EOF at the end of each project statement.