### PR TITLE
Make `extend` parsing closer to `summarize` parsing

### DIFF
--- a/parser/ast.go
+++ b/parser/ast.go
@@ -269,9 +269,8 @@ func (op *ExtendOperator) Span() Span {
 }
 
 // A ExtendColumn is a single column term in a [ExtendOperator].
-// It consists of a column name,
-// and must be followed by an expression specifying how to compute the column.
-// If the expression is omitted, it is invalid.
+// It consists of an expression, optionally preceded by a column name.
+// If the column name is omitted, one is derived from the expression.
 type ExtendColumn struct {
 	Name   *Ident
 	Assign Span

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -416,42 +416,50 @@ func (p *parser) extendOperator(pipe, keyword Token) (*ExtendOperator, error) {
 	}
 
 	for {
-		colName, err := p.ident()
+		col, err := p.extendColumn()
 		if err != nil {
 			return op, makeErrorOpaque(err)
-		}
-		col := &ExtendColumn{
-			Name:   colName,
-			Assign: nullSpan(),
 		}
 		op.Cols = append(op.Cols, col)
 
 		sep, ok := p.next()
 		if !ok {
-			return op, fmt.Errorf("expected '=' followed by expression for assignment, got EOF")
-		}
-
-		// Unlike in project, extend must be an assignment after
-		// the column name token. And afterwards the token must be
-		// a comma as a separator
-		if sep.Kind != TokenAssign {
-			return op, makeErrorOpaque(err)
-		}
-
-		col.Assign = sep.Span
-		col.X, err = p.expr()
-		if err != nil {
-			return op, makeErrorOpaque(err)
-		}
-		sep, ok = p.next()
-		if !ok {
 			return op, nil
 		}
 		if sep.Kind != TokenComma {
-			return op, fmt.Errorf("expected '=' followed by expression for assignment, got EOF")
-
+			p.prev()
+			return op, nil
 		}
 	}
+}
+
+func (p *parser) extendColumn() (*ExtendColumn, error) {
+	restorePos := p.pos
+
+	col := &ExtendColumn{
+		Assign: nullSpan(),
+	}
+
+	var err error
+	col.Name, err = p.ident()
+	if err == nil {
+		if assign, _ := p.next(); assign.Kind == TokenAssign {
+			col.Assign = assign.Span
+		} else {
+			col.Name = nil
+			p.pos = restorePos
+		}
+	} else if !isNotFound(err) {
+		col.X = col.Name.AsQualified()
+		col.Name = nil
+		return col, makeErrorOpaque(err)
+	}
+
+	col.X, err = p.expr()
+	if col.Name != nil {
+		err = makeErrorOpaque(err)
+	}
+	return col, err
 }
 
 func (p *parser) summarizeOperator(pipe, keyword Token) (*SummarizeOperator, error) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1219,6 +1219,99 @@ var parserTests = []struct {
 		},
 	},
 	{
+		name:  "ExtendExprOnly",
+		query: "StormEvents | extend InjuriesDirect + InjuriesIndirect",
+		want: &TabularExpr{
+			Source: &TableRef{
+				Table: &Ident{
+					Name:     "StormEvents",
+					NameSpan: newSpan(0, 11),
+				},
+			},
+			Operators: []TabularOperator{
+				&ExtendOperator{
+					Pipe:    newSpan(12, 13),
+					Keyword: newSpan(14, 20),
+					Cols: []*ExtendColumn{
+						{
+							Assign: nullSpan(),
+							X: &BinaryExpr{
+								X: (&Ident{
+									Name:     "InjuriesDirect",
+									NameSpan: newSpan(21, 35),
+								}).AsQualified(),
+								OpSpan: newSpan(36, 37),
+								Op:     TokenPlus,
+								Y: (&Ident{
+									Name:     "InjuriesIndirect",
+									NameSpan: newSpan(38, 54),
+								}).AsQualified(),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name:  "ExtendExprMultiple",
+		query: "StormEvents | extend TotalInjuries = InjuriesDirect + InjuriesIndirect, Duration = EndTime - StartTime",
+		want: &TabularExpr{
+			Source: &TableRef{
+				Table: &Ident{
+					Name:     "StormEvents",
+					NameSpan: newSpan(0, 11),
+				},
+			},
+			Operators: []TabularOperator{
+				&ExtendOperator{
+					Pipe:    newSpan(12, 13),
+					Keyword: newSpan(14, 20),
+					Cols: []*ExtendColumn{
+						{
+							Name: &Ident{
+								Name:     "TotalInjuries",
+								NameSpan: newSpan(21, 34),
+							},
+							Assign: newSpan(35, 36),
+							X: &BinaryExpr{
+								X: (&Ident{
+									Name:     "InjuriesDirect",
+									NameSpan: newSpan(37, 51),
+								}).AsQualified(),
+								OpSpan: newSpan(52, 53),
+								Op:     TokenPlus,
+								Y: (&Ident{
+									Name:     "InjuriesIndirect",
+									NameSpan: newSpan(54, 70),
+								}).AsQualified(),
+							},
+						},
+						{
+							Name: &Ident{
+								Name:     "Duration",
+								NameSpan: newSpan(72, 80),
+							},
+							Assign: newSpan(81, 82),
+							X: &BinaryExpr{
+								X: (&Ident{
+									Name:     "EndTime",
+									NameSpan: newSpan(83, 90),
+								}).AsQualified(),
+								OpSpan: newSpan(91, 92),
+								Op:     TokenMinus,
+								Y: (&Ident{
+									Name:     "StartTime",
+									NameSpan: newSpan(93, 102),
+								}).AsQualified(),
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
 		name:  "ExtendError",
 		query: "StormEvents | extend FooFooF=1 State",
 		err:   true,

--- a/testdata/Goldens/ExtendExprOnly/input.pql
+++ b/testdata/Goldens/ExtendExprOnly/input.pql
@@ -1,0 +1,3 @@
+StormEvents
+| project State, EventType, DamageProperty
+| extend 42

--- a/testdata/Goldens/ExtendExprOnly/output.csv
+++ b/testdata/Goldens/ExtendExprOnly/output.csv
@@ -1,0 +1,6 @@
+State,EventType,DamageProperty,42
+ATLANTIC SOUTH,Waterspout,0,42
+FLORIDA,Heavy Rain,0,42
+FLORIDA,Tornado,6200000,42
+GEORGIA,Thunderstorm Wind,2000,42
+MISSISSIPPI,Thunderstorm Wind,20000,42

--- a/testdata/Goldens/ExtendExprOnly/output.sql
+++ b/testdata/Goldens/ExtendExprOnly/output.sql
@@ -1,0 +1,2 @@
+WITH "__subquery0" AS (SELECT "State" AS "State", "EventType" AS "EventType", "DamageProperty" AS "DamageProperty" FROM "StormEvents")
+SELECT *, 42 AS "42" FROM "__subquery0";


### PR DESCRIPTION
Add more tests around multiple columns and omitting the name.

Fixes #50