### PR TITLE
Add test for using a dollar sign in a parameter name

### DIFF
--- a/testdata/Goldens/ParamsDollarSign/input.pql
+++ b/testdata/Goldens/ParamsDollarSign/input.pql
@@ -1,0 +1,2 @@
+Tokens
+| where Kind == $desiredKind

--- a/testdata/Goldens/ParamsDollarSign/options.jwcc
+++ b/testdata/Goldens/ParamsDollarSign/options.jwcc
@@ -1,0 +1,8 @@
+{
+  "parameters": {
+    "$desiredKind": {
+      "clickhouse": "{$desiredKind: Int32}",
+      "value": "1",
+    },
+  },
+}

--- a/testdata/Goldens/ParamsDollarSign/output.csv
+++ b/testdata/Goldens/ParamsDollarSign/output.csv
@@ -1,0 +1,2 @@
+Kind,TokenConstant
+1,TokenIdentifier

--- a/testdata/Goldens/ParamsDollarSign/output.sql
+++ b/testdata/Goldens/ParamsDollarSign/output.sql
@@ -1,0 +1,1 @@
+SELECT * FROM "Tokens" WHERE coalesce("Kind" = {$desiredKind: Int32}, FALSE);


### PR DESCRIPTION
Already supported, but in discussion about parameters, realized that we may want parameters to stand out from other elements. This test ensures that this use case is supported. (I was surprised to discover that Clickhouse also supports dollar signs in their identifiers.)